### PR TITLE
Add usage to readme and test image

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,5 @@
-on: [push]
+on:
+  - workflow_dispatch
 
 jobs:
   spell-check:
@@ -10,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Spell check action
-        uses: ./ # Uses an action in the root directory
+        uses: ./ # Uses the action in the root directory
         id: spell
       # Use the output from the `spell check` step
       - name: Get the number of errors

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
           dictionary: components/dictionary.txt
 
       - name: Upload spell check errors
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: spell_check_errors
           path: spell_check_errors.tsv

--- a/README.md
+++ b/README.md
@@ -1,6 +1,51 @@
 # spellcheck
 
-This repository contains a Docker image with the [R `spelling` package](https://cran.r-project.org/web/packages/spelling/index.html) installed.
-The role of this repository is to facilitate spell checking actions across `AlexsLemonade` repositories.
+This repository contains a GitHub action to run the [R `spelling` package](https://cran.r-project.org/web/packages/spelling/index.html).
+The role of this action is to facilitate spell checking actions across `AlexsLemonade` repositories.
 
-speeling
+Currently the action will only spell check text in Rmd and md files
+
+## Usage
+
+To use this action, create a `.github/workflows/spellcheck.yml` file in your repository with the following contents (modified to fit your exact needs):
+
+```yaml
+name: Check Spelling
+on:
+  pull_request:
+    branches:
+     - main
+
+jobs:
+  spell-check:
+    runs-on: ubuntu-latest
+    name: Spell check files
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Spell check action
+        uses: alexslemonade/spellcheck
+        id: spell
+        with:
+          dictionary: components/dictionary.txt
+
+      - name: Upload spell check errors
+        uses: actions/upload-artifact@v2
+        with:
+          name: spell_check_errors
+          path: spell_check_errors.tsv
+
+      - name: Fail if there are spelling errors
+        if: steps.spell.outputs.error_count > 0
+        run: |
+          echo "There were ${{ steps.spell.outputs.error_count }} errors"
+          exit 1
+```
+
+Note that the `dictionary` input to the spell check step is optional and defaults to `components/dictionary.txt`.
+If you want to use a different dictionary, you can specify the path to the dictionary file in your repository.
+
+You can also specify specific files to spell check using the `files` input to the `alexslemonade/spellcheck` step.
+Globs should work as expected.

--- a/action.yaml
+++ b/action.yaml
@@ -1,11 +1,11 @@
 # action.yml
-name: 'R spell check'
-description: 'Spell check R, Rmd and md files'
+name: "R spell check"
+description: "Spell check R, Rmd and md files"
 inputs:
-  dictionary:  # id of input
-    description: 'Dictionary file path'
+  dictionary: # id of input
+    description: "Dictionary file path"
     required: true
-    default: 'components/dictionary.txt'
+    default: "components/dictionary.txt"
   files:
     description: Glob of files to check
     required: false
@@ -13,8 +13,8 @@ outputs:
   error_count:
     description: The number of spelling errors
 runs:
-  using: 'docker'
+  using: "docker"
   image: ghcr.io/alexslemonade/spellcheck:edge
   args:
-    - ${{ inputs.dictionary }}
+    - ${{ inputs.dictionary || 'components/dictionary.txt'  }}
     - ${{ inputs.files }}

--- a/action.yaml
+++ b/action.yaml
@@ -16,5 +16,5 @@ runs:
   using: "docker"
   image: ghcr.io/alexslemonade/spellcheck:edge
   args:
-    - ${{ inputs.dictionary || 'components/dictionary.txt'  }}
+    - ${{ inputs.dictionary || '/dev/null'  }}
     - ${{ inputs.files }}

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ outputs:
     description: The number of spelling errors
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: ghcr.io/alexslemonade/spelling:edge
   args:
     - ${{ inputs.dictionary }}
     - ${{ inputs.files }}

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ outputs:
     description: The number of spelling errors
 runs:
   using: 'docker'
-  image: ghcr.io/alexslemonade/spelling:edge
+  image: ghcr.io/alexslemonade/spellcheck:edge
   args:
     - ${{ inputs.dictionary }}
     - ${{ inputs.files }}

--- a/spell-check.R
+++ b/spell-check.R
@@ -12,7 +12,7 @@ dict_file <- arguments[1]
 
 arguments <- arguments[-1]
 # if there are arguments, check those files, otherwise check all markdown & rmd files
-if (length(arguments) > 1) {
+if (length(arguments) > 0) {
   files <- arguments[grepl(file_pattern, arguments)]
 } else {
   files <- list.files(pattern = file_pattern, recursive = TRUE, full.names = TRUE)


### PR DESCRIPTION
This PR currently tests the workflow in the `test.yaml` action, but the main purpose is to test that the action works as expected _somewhere else_ following the instructions in the readme that I have added. 

@sjspielman: Can you try adding that workflow to another repo to see if it works as expected?

If it does, we can decide on a release version, add those tags as appropriate here, then merge and tag the actual release. (Probably removing the test action, or making it only run on workflow_dispatch)