### PR TITLE
Tag versions for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a GitHub action to run the [R `spelling` package](https://cran.r-project.org/web/packages/spelling/index.html).
 The role of this action is to facilitate spell checking actions across `AlexsLemonade` repositories.
 
-Currently the action will only spell check text in Rmd and md files
+Currently the action will only spell check text in Markdown (`.md`) and Rmarkdown (`.Rmd`) files.
 
 ## Usage
 
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Spell check action
-        uses: alexslemonade/spellcheck
+        uses: alexslemonade/spellcheck@v0
         id: spell
         with:
           dictionary: components/dictionary.txt
@@ -48,4 +48,5 @@ Note that the `dictionary` input to the spell check step is optional and default
 If you want to use a different dictionary, you can specify the path to the dictionary file in your repository.
 
 You can also specify specific files to spell check using the `files` input to the `alexslemonade/spellcheck` step.
+Note that the file extenstion restriction will still apply.
 Globs should work as expected.

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ outputs:
     description: The number of spelling errors
 runs:
   using: "docker"
-  image: ghcr.io/alexslemonade/spellcheck:edge
+  image: ghcr.io/alexslemonade/spellcheck:v0.1.0
   args:
     - ${{ inputs.dictionary || '/dev/null'  }}
     - ${{ inputs.files }}

--- a/spell-check.R
+++ b/spell-check.R
@@ -5,7 +5,7 @@
 # To modify this behavior, provide a command-line argument with the extensions to check.
 
 arguments <- commandArgs(trailingOnly = TRUE)
-file_pattern <- "\\.(Rmd|md|rmd)$"
+file_pattern <- "(?i)\\.(md|rmd)$"
 
 # dictionary is required first argument
 dict_file <- arguments[1]


### PR DESCRIPTION
I think this PR, followed by a v0.1.0 release, should make this action fully operational. 

I did make a small change to the script to make the extensions case-insensitive, but other than that I just added some versioning. 

The docker image tag won't work until the release is made and the docker image builds. But that should not take long once this is merged!