### PR TITLE
Add check for blank second arg

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ outputs:
     description: The number of spelling errors
 runs:
   using: "docker"
-  image: docker://ghcr.io/alexslemonade/spellcheck:v0.1.0
+  image: docker://ghcr.io/alexslemonade/spellcheck:v0.1.1
   args:
     - ${{ inputs.dictionary || '/dev/null'  }}
     - ${{ inputs.files }}

--- a/spell-check.R
+++ b/spell-check.R
@@ -5,6 +5,7 @@
 # To modify this behavior, provide a command-line argument with the extensions to check.
 
 arguments <- commandArgs(trailingOnly = TRUE)
+
 file_pattern <- "(?i)\\.(md|rmd)$"
 
 # dictionary is required first argument
@@ -12,7 +13,7 @@ dict_file <- arguments[1]
 
 arguments <- arguments[-1]
 # if there are arguments, check those files, otherwise check all markdown & rmd files
-if (length(arguments) > 0) {
+if (length(arguments) > 0 && arguments[1] != "") {
   files <- arguments[grepl(file_pattern, arguments)]
 } else {
   files <- list.files(pattern = file_pattern, recursive = TRUE, full.names = TRUE)


### PR DESCRIPTION
It appears that github is always supplying the second argument, making the script check no files if no file list is given. So I think this should fix https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/138#pullrequestreview-1928664948.

