### PR TITLE
make push more discriminating

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
     tags:
-      - "v*"
+      # only run with semver tags
+      - "v*.*.*"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
I added a tag `v0` that we can keep up to date with the latest version in that major version, but that triggered a failed push. So here I am updating the workflow only to stop that for next time. 

(Adding the `v0` tag should enable the suggestion I made in https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/138#discussion_r1520368468)

