### PR TITLE
Update file glob code

### DIFF
--- a/spell-check.R
+++ b/spell-check.R
@@ -16,7 +16,8 @@ arguments <- arguments[-1]
 if (length(arguments) > 0 && arguments[1] != "") {
   files_glob <- strsplit(arguments, " ") |>
     unlist() |>
-    Sys.glob()
+    Sys.glob() |>
+    unique()
   files <- grep(file_pattern, files_glob, value = TRUE)
 } else {
   files <- list.files(pattern = file_pattern, recursive = TRUE, full.names = TRUE)

--- a/spell-check.R
+++ b/spell-check.R
@@ -14,7 +14,10 @@ dict_file <- arguments[1]
 arguments <- arguments[-1]
 # if there are arguments, check those files, otherwise check all markdown & rmd files
 if (length(arguments) > 0 && arguments[1] != "") {
-  files <- arguments[grepl(file_pattern, arguments)]
+  files_glob <- strsplit(arguments, " ") |>
+    unlist() |>
+    Sys.glob()
+  files <- grep(file_pattern, files_glob, value = TRUE)
 } else {
   files <- list.files(pattern = file_pattern, recursive = TRUE, full.names = TRUE)
 }


### PR DESCRIPTION
This PR updates parsing to handle file globs better. 

Noting that I tested this locally to see if we can grab all the OpenScPCA docs files, and it worked with `"docs/* docs/*/* docs/*/*/*"` to get all the nested docs levels. `**` didn't change the behavior and all three arguments do seem to be needed.

After this goes in, we'll want to bump the ~release~ tag and update its usage in `OpenScPCA-analysis` accordingly.