### PR TITLE
Bump R version 4.4 & action to 0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # A docker file for establishing a spellcheck environment in R
-FROM rocker/r-ver:4.3.2
+FROM rocker/r-ver:4.4.0
 
 # Labels following the Open Containers Initiative (OCI) recommendations
 # For more information, see https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ outputs:
     description: The number of spelling errors
 runs:
   using: "docker"
-  image: docker://ghcr.io/alexslemonade/spellcheck:v0.1.4
+  image: docker://ghcr.io/alexslemonade/spellcheck:v0.2.0
   args:
     - ${{ inputs.dictionary || '/dev/null'  }}
     - ${{ inputs.files }}

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ outputs:
     description: The number of spelling errors
 runs:
   using: "docker"
-  image: docker://ghcr.io/alexslemonade/spellcheck:v0.1.3
+  image: docker://ghcr.io/alexslemonade/spellcheck:v0.1.4
   args:
     - ${{ inputs.dictionary || '/dev/null'  }}
     - ${{ inputs.files }}


### PR DESCRIPTION
As long as we are doing security updates to R 4.4 everywhere else, this one was pretty easy to add in. After this goes in I will release version 0.2. Why the big jump? Matching R, I guess.