### PR TITLE
Make spellcheck run vanilla

### DIFF
--- a/spell-check.R
+++ b/spell-check.R
@@ -1,4 +1,4 @@
-#!/usr/bin/env Rscript
+#!/usr/bin/env Rscript --vanilla
 #
 # Run spell check and save results.
 # By default, all R Markdown and markdown files will be checked.


### PR DESCRIPTION
I ran into an issue when [running the workflow](https://github.com/AlexsLemonade/training-modules/actions/runs/9162557223/job/25189776758?pr=766) where it was trying to load an renv but that failed. The problem seems to be that the repo I was in had a `.Rprofile` file, which `Rscript` then tried to use. So here I added `--vanilla` to the shebang, which ought to do what we need. 

Updated the version string while I was at it.